### PR TITLE
Improve accessibility for dependency item status

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -7,6 +7,7 @@ src/ui/dashboardBox.js
 src/ui/dashboardBox.ui
 src/dependencyCheck.js
 src/ui/dependencyItem.ui
+src/ui/dependencyItem.js
 src/main.js
 src/ui/moreInfo.ui
 src/networkState.js

--- a/po/bouncer.pot
+++ b/po/bouncer.pot
@@ -567,5 +567,5 @@ msgid "Not Ready"
 msgstr ""
 
 #: src/ui/dependencyItem.js:56
-msgid "Error"
+msgid "Suboptimal"
 msgstr ""

--- a/po/bouncer.pot
+++ b/po/bouncer.pot
@@ -563,9 +563,9 @@ msgid "Ready"
 msgstr ""
 
 #: src/ui/dependencyItem.js:54
-msgid "Not Ready"
+msgid "Suboptimal"
 msgstr ""
 
 #: src/ui/dependencyItem.js:56
-msgid "Suboptimal"
+msgid "Not Ready"
 msgstr ""

--- a/po/bouncer.pot
+++ b/po/bouncer.pot
@@ -553,3 +553,19 @@ msgid ""
 "Bouncer ran into an error determining network state. This is required for "
 "the application to work correctly. Please see logs for more information."
 msgstr ""
+
+#: src/ui/dependencyItem.js:50
+msgid "Unknown"
+msgstr ""
+
+#: src/ui/dependencyItem.js:52
+msgid "Ready"
+msgstr ""
+
+#: src/ui/dependencyItem.js:54
+msgid "Not Ready"
+msgstr ""
+
+#: src/ui/dependencyItem.js:56
+msgid "Error"
+msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -690,5 +690,5 @@ msgid "Not Ready"
 msgstr ""
 
 #: src/ui/dependencyItem.js:56
-msgid "Error"
+msgid "Suboptimal"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -686,9 +686,9 @@ msgid "Ready"
 msgstr ""
 
 #: src/ui/dependencyItem.js:54
-msgid "Not Ready"
+msgid "Suboptimal"
 msgstr ""
 
 #: src/ui/dependencyItem.js:56
-msgid "Suboptimal"
+msgid "Not Ready"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -676,3 +676,19 @@ msgstr ""
 
 #~ msgid "D-Bus"
 #~ msgstr "D-Bus"
+
+#: src/ui/dependencyItem.js:50
+msgid "Unknown"
+msgstr ""
+
+#: src/ui/dependencyItem.js:52
+msgid "Ready"
+msgstr ""
+
+#: src/ui/dependencyItem.js:54
+msgid "Not Ready"
+msgstr ""
+
+#: src/ui/dependencyItem.js:56
+msgid "Error"
+msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -692,5 +692,5 @@ msgid "Not Ready"
 msgstr ""
 
 #: src/ui/dependencyItem.js:56
-msgid "Error"
+msgid "Suboptimal"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -678,3 +678,19 @@ msgstr ""
 #~ msgstr ""
 #~ "Open Bouncer om automatisch opstarten in te schakelen. Als het goed is "
 #~ "moet u een melding krijgen dat het systeem goed is afgesteld."
+
+#: src/ui/dependencyItem.js:50
+msgid "Unknown"
+msgstr ""
+
+#: src/ui/dependencyItem.js:52
+msgid "Ready"
+msgstr ""
+
+#: src/ui/dependencyItem.js:54
+msgid "Not Ready"
+msgstr ""
+
+#: src/ui/dependencyItem.js:56
+msgid "Error"
+msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -688,9 +688,9 @@ msgid "Ready"
 msgstr ""
 
 #: src/ui/dependencyItem.js:54
-msgid "Not Ready"
+msgid "Suboptimal"
 msgstr ""
 
 #: src/ui/dependencyItem.js:56
-msgid "Suboptimal"
+msgid "Not Ready"
 msgstr ""

--- a/po/oc.po
+++ b/po/oc.po
@@ -719,5 +719,5 @@ msgid "Not Ready"
 msgstr ""
 
 #: src/ui/dependencyItem.js:56
-msgid "Error"
+msgid "Suboptimal"
 msgstr ""

--- a/po/oc.po
+++ b/po/oc.po
@@ -715,9 +715,9 @@ msgid "Ready"
 msgstr ""
 
 #: src/ui/dependencyItem.js:54
-msgid "Not Ready"
+msgid "Suboptimal"
 msgstr ""
 
 #: src/ui/dependencyItem.js:56
-msgid "Suboptimal"
+msgid "Not Ready"
 msgstr ""

--- a/po/oc.po
+++ b/po/oc.po
@@ -705,3 +705,19 @@ msgstr ""
 #~ "Aviatz Bouncer manualament un còp per activar l'aviada automatica. "
 #~ "Deuriatz veire una notificacion qu'indica que lo sistèma es configurat "
 #~ "corrèctament per Bouncer."
+
+#: src/ui/dependencyItem.js:50
+msgid "Unknown"
+msgstr ""
+
+#: src/ui/dependencyItem.js:52
+msgid "Ready"
+msgstr ""
+
+#: src/ui/dependencyItem.js:54
+msgid "Not Ready"
+msgstr ""
+
+#: src/ui/dependencyItem.js:56
+msgid "Error"
+msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -671,9 +671,9 @@ msgid "Ready"
 msgstr ""
 
 #: src/ui/dependencyItem.js:54
-msgid "Not Ready"
+msgid "Suboptimal"
 msgstr ""
 
 #: src/ui/dependencyItem.js:56
-msgid "Suboptimal"
+msgid "Not Ready"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -675,5 +675,5 @@ msgid "Not Ready"
 msgstr ""
 
 #: src/ui/dependencyItem.js:56
-msgid "Error"
+msgid "Suboptimal"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -661,3 +661,19 @@ msgid ""
 msgstr ""
 "Bouncer napotkał problem przy ustalaniu stanu sieci. Jest to wymagane do "
 "poprawnego działania aplikacji. Sprawdź logi po więcej informacji."
+
+#: src/ui/dependencyItem.js:50
+msgid "Unknown"
+msgstr ""
+
+#: src/ui/dependencyItem.js:52
+msgid "Ready"
+msgstr ""
+
+#: src/ui/dependencyItem.js:54
+msgid "Not Ready"
+msgstr ""
+
+#: src/ui/dependencyItem.js:56
+msgid "Error"
+msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -691,3 +691,19 @@ msgstr ""
 #~ "Для активации автозагрузки запустите Bouncer вручную. Вы увидите "
 #~ "уведомление, указывающее на корректную настройку системы для работы с "
 #~ "Bouncer."
+
+#: src/ui/dependencyItem.js:50
+msgid "Unknown"
+msgstr ""
+
+#: src/ui/dependencyItem.js:52
+msgid "Ready"
+msgstr ""
+
+#: src/ui/dependencyItem.js:54
+msgid "Not Ready"
+msgstr ""
+
+#: src/ui/dependencyItem.js:56
+msgid "Error"
+msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -705,5 +705,5 @@ msgid "Not Ready"
 msgstr ""
 
 #: src/ui/dependencyItem.js:56
-msgid "Error"
+msgid "Suboptimal"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -701,9 +701,9 @@ msgid "Ready"
 msgstr ""
 
 #: src/ui/dependencyItem.js:54
-msgid "Not Ready"
+msgid "Suboptimal"
 msgstr ""
 
 #: src/ui/dependencyItem.js:56
-msgid "Suboptimal"
+msgid "Not Ready"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -638,16 +638,16 @@ msgstr ""
 
 #: src/ui/dependencyItem.js:50
 msgid "Unknown"
-msgstr ""
+msgstr "未知"
 
 #: src/ui/dependencyItem.js:52
 msgid "Ready"
-msgstr ""
+msgstr "就绪"
 
 #: src/ui/dependencyItem.js:54
-msgid "Not Ready"
-msgstr ""
+msgid "Suboptimal"
+msgstr "次优"
 
 #: src/ui/dependencyItem.js:56
-msgid "Suboptimal"
-msgstr ""
+msgid "Not Ready"
+msgstr "未就绪"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -635,3 +635,19 @@ msgstr ""
 #~ msgstr ""
 #~ "手动启动 Bouncer 一次以启用自动启动。您应该会看到一个通知，表明您的系统已"
 #~ "正确配置为使用 Bouncer。"
+
+#: src/ui/dependencyItem.js:50
+msgid "Unknown"
+msgstr ""
+
+#: src/ui/dependencyItem.js:52
+msgid "Ready"
+msgstr ""
+
+#: src/ui/dependencyItem.js:54
+msgid "Not Ready"
+msgstr ""
+
+#: src/ui/dependencyItem.js:56
+msgid "Error"
+msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -649,5 +649,5 @@ msgid "Not Ready"
 msgstr ""
 
 #: src/ui/dependencyItem.js:56
-msgid "Error"
+msgid "Suboptimal"
 msgstr ""

--- a/src/ui/dependencyItem.js
+++ b/src/ui/dependencyItem.js
@@ -27,13 +27,40 @@ export const DependencyItem = GObject.registerClass({
             'label',
             GObject.BindingFlags.SYNC_CREATE,
             // eslint-disable-next-line no-unused-vars
-            (binding, value) => [true, this.#convertStatus(value)],
+            (binding, value) => [true, this.#convertStatusToIcon(value)],
             null
         );
+
+        dependencyCheck.bind_property_full(
+            property,
+            this._status,
+            'tooltip-text',
+            GObject.BindingFlags.SYNC_CREATE,
+            // eslint-disable-next-line no-unused-vars
+            (binding, value) => [true, this.#convertStatusToText(value)],
+            null
+        );
+
         this._button.connect('clicked', callbackFunction);
     }
 
-    #convertStatus(status) {
+    #convertStatusToText(status) {
+     switch (status) {
+            case 0:
+                return _('Unknown');
+            case 1:
+                return _('Ready');
+            case 2:
+                return _('Not Ready');
+            case 3:
+                return _('Error');
+            default:
+                console.error(`Invalid DependencyItem status: ${status}`);
+                return 'Unknown';
+        }
+    }
+
+    #convertStatusToIcon(status) {
         switch (status) {
             case 0:
                 return '⚪';

--- a/src/ui/dependencyItem.js
+++ b/src/ui/dependencyItem.js
@@ -51,9 +51,9 @@ export const DependencyItem = GObject.registerClass({
             case 1:
                 return _('Ready');
             case 2:
-                return _('Not Ready');
+                return _('Suboptimal');
             case 3:
-                return _('Error');
+                return _('Not Ready');
             default:
                 console.error(`Invalid DependencyItem status: ${status}`);
                 return _('Unknown');

--- a/src/ui/dependencyItem.js
+++ b/src/ui/dependencyItem.js
@@ -56,7 +56,7 @@ export const DependencyItem = GObject.registerClass({
                 return _('Error');
             default:
                 console.error(`Invalid DependencyItem status: ${status}`);
-                return 'Unknown';
+                return _('Unknown');
         }
     }
 

--- a/src/ui/dependencyItem.ui
+++ b/src/ui/dependencyItem.ui
@@ -28,6 +28,8 @@
         <property name="margin-start">12</property>
         <property name="margin-end">12</property>
         <property name="label">⚪</property> <!-- default value will be "unknown" status -->
+        <property name="has-tooltip">true</property>
+        <property name="tooltip-text" translatable="yes">Unknown</property>
       </object>
     </child>
   </template>


### PR DESCRIPTION
Currently the dependency item component uses color coded symbols to convey status to the user. As someone who is red/green color blind, I was unable to tell the status of items. This PR adds tool tips that convey the status when the icon is hovered, making the page accessible for color blind users.

<img width="614" height="496" alt="Screenshot From 2026-05-07 16-13-23" src="https://github.com/user-attachments/assets/748d48bc-f18a-44ac-b268-0542bb2cba9d" />
